### PR TITLE
Adding skeleton for new image io infrastructure

### DIFF
--- a/examples/square.jl
+++ b/examples/square.jl
@@ -42,7 +42,6 @@ function main(num_particles, num_iterations, AT; dark = true)
     Fae.fractal_flame!(pix, H, H2, num_particles, num_iterations,
                        bounds, res; AT = AT, FT = FT)
 
-    return pix
     filename = "out.png"
     write_image([pix], filename)
 end

--- a/examples/square.jl
+++ b/examples/square.jl
@@ -34,12 +34,15 @@ function main(num_particles, num_iterations, AT; dark = true)
     H2 = Hutchinson([Flames.swirl],
                     [Fae.Colors.previous],
                     (1.0,);
-                    diagnostic = true, AT = AT, name = "2")
-    final_H = fee([H, H2])
+                    diagnostic = true, AT = AT, name = "2", final = true)
+    #final_H = fee([H, H2])
 
-    pix = Fae.fractal_flame(final_H, num_particles, num_iterations,
-                            bounds, res; AT = AT, FT = FT)
+    pix = Pixels(res; AT = AT, logscale = false, FT = FT)
 
+    Fae.fractal_flame!(pix, H, H2, num_particles, num_iterations,
+                       bounds, res; AT = AT, FT = FT)
+
+    return pix
     filename = "out.png"
     write_image([pix], filename)
 end

--- a/src/fractal_flame.jl
+++ b/src/fractal_flame.jl
@@ -33,7 +33,7 @@ function iterate!(ps::Points, pxs::Pixels, H::Hutchinson, n,
 
     kernel!(ps.positions, n, H.op, H.cop, H.prob_set, H.symbols, H.fnums,
             H2.op, H2.cop, H2.symbols, H2.prob_set, H2.fnums,
-            pxs.values, pxs.reds, pxs.greens, pxs.blues,
+            pxs.values, pxs.reds, pxs.greens, pxs.blues, pxs.alphas, 
             Tuple(bounds), Tuple(bin_widths), num_ignore, max_range,
             ndrange=size(ps.positions)[1])
 end
@@ -42,8 +42,8 @@ end
                                      H1_symbols, H1_fnums, H2, H2_clrs,
                                      H2_symbols, H2_probs, H2_fnums,
                                      pixel_values, pixel_reds, pixel_greens,
-                                     pixel_blues, bounds, bin_widths,
-                                     num_ignore, max_range)
+                                     pixel_blues, pixel_alphas, bounds,
+                                     bin_widths, num_ignore, max_range)
 
     tid = @index(Global,Linear)
     lid = @index(Local, Linear)
@@ -120,6 +120,7 @@ end
                     @inbounds @atomic pixel_blues[bin] +=
                                   shared_colors[lid, 3] *
                                   shared_colors[lid, 4]
+                    @inbounds @atomic pixel_alphas[bin] += shared_colors[lid, 4]
                 end
             end
         end

--- a/src/fractal_flame.jl
+++ b/src/fractal_flame.jl
@@ -134,10 +134,10 @@ end
 function fractal_flame(H1::Hutchinson, H2::Hutchinson, num_particles::Int,
                        num_iterations::Int, bounds, res;
                        dims = 2, AT = Array, FT = Float32, diagnostic = false,
-                       num_ignore = 20, numthreads = 256,
+                       num_ignore = 20, numthreads = 256, logscale = true, 
                        numcores = 4)
 
-    pix = Pixels(res; AT = AT, FT = FT)
+    pix = Pixels(res; AT = AT, FT = FT, logscale = logscale)
 
     fractal_flame!(pix, H1, num_particles, num_iterations, bounds, res;
                    dims = dims, AT = AT, FT = FT, H2 = H2,
@@ -161,7 +161,7 @@ end
 function fractal_flame(H::Hutchinson, num_particles::Int,
                        num_iterations::Int, bounds, res;
                        dims = 2, AT = Array, FT = Float32, H2 = Hutchinson(),
-                       num_ignore = 20, diagnostic = false,
+                       num_ignore = 20, diagnostic = false, logscale = true, 
                        numthreads = 256, numcores = 4)
 
     pix = Pixels(res; AT = AT, FT = FT)

--- a/src/postprocessing/io_structs.jl
+++ b/src/postprocessing/io_structs.jl
@@ -7,6 +7,7 @@ mutable struct Pixels
     reds::Union{Array{T}, CuArray{T}} where T <: AbstractFloat
     greens::Union{Array{T}, CuArray{T}} where T <: AbstractFloat
     blues::Union{Array{T}, CuArray{T}} where T <: AbstractFloat
+    alphas::Union{Array{T}, CuArray{T}} where T <: AbstractFloat
     gamma::Number
     logscale::Bool
     calc_max_value::Bool
@@ -14,16 +15,16 @@ mutable struct Pixels
 end
 
 # Creating a default call
-function Pixels(v, r, g, b; gamma = 2.2, logscale = true,
+function Pixels(v, r, g, b, a; gamma = 2.2, logscale = true,
                 calc_max_value = true, max_value = 0)
-    return Pixels(v, r, g, b, gamma, logscale, calc_max_value, max_value)
+    return Pixels(v, r, g, b, a, gamma, logscale, calc_max_value, max_value)
 end
 
 # Create a blank, black image of size s
 function Pixels(s; AT=Array, FT = Float64, gamma = 2.2, logscale = true,
                 calc_max_value = true, max_value = 0)
     return Pixels(AT(zeros(Int,s)), AT(zeros(FT, s)),
-                  AT(zeros(FT, s)), AT(zeros(FT, s)),
+                  AT(zeros(FT, s)), AT(zeros(FT, s)), AT(zeros(FT, s)),
                   gamma, logscale, calc_max_value, max_value)
 end
 

--- a/src/postprocessing/io_tools.jl
+++ b/src/postprocessing/io_tools.jl
@@ -51,7 +51,7 @@ function logscale_coalesce!(pix, layer; numcores = 4, numthreads = 256)
         kernel! = logscale_coalesce_kernel!(CUDADevice(), numthreads)
     end
 
-    kernel!(pix.reds, pix.blues, pix.greens, pix.alphas, pix.values,
+    kernel!(pix.reds, pix.greens, pix.blues, pix.alphas, pix.values,
             layer.reds, layer.greens, layer.blues, layer.alphas, layer.values,
             layer.gamma, layer.max_value, ndrange=length(pix.reds))
 
@@ -87,7 +87,7 @@ function norm_pixel(color, value)
     end
 end
 
-function add_layer!(pix::Pixels, layer::Pixels)
+function add_layer!(pix::Pixels, layer::Pixels; numcores = 4, numthreads = 256)
 
     # naive normalization
     layer.reds .= norm_pixel.(layer.reds, layer.values)
@@ -111,13 +111,8 @@ end
 function write_image(pixels::Vector{Pixels}, filename;
                      img = fill(RGB(0,0,0), size(pixels[1].values)),
                      numcores = 4, numthreads = 256)
-    # naive normalization
-    pixels[1].reds .= norm_pixel.(pixels[1].reds, pixels[1].values)
-    pixels[1].greens .= norm_pixel.(pixels[1].greens, pixels[1].values)
-    pixels[1].blues .= norm_pixel.(pixels[1].blues, pixels[1].values)
-    pixels[1].alphas .= norm_pixel.(pixels[1].alphas, pixels[1].values)
 
-    for i = 2:length(pixels)
+    for i = 1:length(pixels)
         add_layer!(pixels[1], pixels[i])
     end
 
@@ -129,7 +124,7 @@ end
 
 function write_video!(v::VideoParams, pixels::Vector{Pixels};
                       numcores = 4, numthreads = 256)
-    for i = 2:length(pixels)
+    for i = 1:length(pixels)
         add_layer!(pixels[1], pixels[i])
     end
 


### PR DESCRIPTION
This makes image io like 100x faster and also gets red of grainy-ness from the naive chaos kernel for non-logarithmic pixel sets.

Note that creating a faster flame solver for uniform shapes is another beast entirely ^^